### PR TITLE
Refacto/spells detect

### DIFF
--- a/Necrosis/Initialize.lua
+++ b/Necrosis/Initialize.lua
@@ -164,6 +164,7 @@ function Necrosis:Initialize(Config)
 		self.Speech.Rez = self.Speech.ShortMessage[1]
 		self.Speech.TP = self.Speech.ShortMessage[2]
 	end
+	self:Msg("Ready", "USER")
 end
 
 

--- a/Necrosis/Initialize.lua
+++ b/Necrosis/Initialize.lua
@@ -97,8 +97,8 @@ function Necrosis:Initialize(Config)
 		self.Spell[index].ID = nil
 	end
 	self:SpellLocalize()
-	self:CreateSpellList()
 	self:SpellSetup()
+	self:CreateSpellList()
 	self:CreateMenu()
 	self:ButtonSetup()
     -- Enregistrement de la commande console

--- a/Necrosis/Initialize.lua
+++ b/Necrosis/Initialize.lua
@@ -97,6 +97,7 @@ function Necrosis:Initialize(Config)
 		self.Spell[index].ID = nil
 	end
 	self:SpellLocalize()
+	self:CreateSpellList()
 	self:SpellSetup()
 	self:CreateMenu()
 	self:ButtonSetup()

--- a/Necrosis/Initialize.lua
+++ b/Necrosis/Initialize.lua
@@ -97,8 +97,8 @@ function Necrosis:Initialize(Config)
 		self.Spell[index].ID = nil
 	end
 	self:SpellLocalize()
-	self:SpellSetup()
 	self:CreateSpellList()
+	self:SpellSetup()
 	self:CreateMenu()
 	self:ButtonSetup()
     -- Enregistrement de la commande console

--- a/Necrosis/Necrosis.lua
+++ b/Necrosis/Necrosis.lua
@@ -103,6 +103,7 @@ local metatable = {
 
 -- Create the spell metatable. || Création de la métatable contenant les sorts de nécrosis
 Necrosis.Spell = setmetatable({}, metatable)
+Necrosis.Spells = setmetatable({}, metatable)
 Necrosis.SpellRef = setmetatable({}, metatable)
 
 ------------------------------------------------------------------------------------------------------

--- a/Necrosis/Necrosis.lua
+++ b/Necrosis/Necrosis.lua
@@ -345,6 +345,7 @@ function Necrosis:OnLoad(event)
 				Necrosis.Spell[index].ID = nil
 			end
 			Necrosis:SpellSetup()
+			Necrosis:CreateSpellList()
 			-- Necrosis:CreateMenu()
 			Necrosis:ButtonSetup()
 		end
@@ -599,6 +600,7 @@ function Necrosis:OnEvent(self, event,...)
 			Necrosis.Spell[index].ID = nil
 		end
 		Necrosis:SpellSetup()
+		Necrosis:CreateSpellList()
 		Necrosis:CreateMenu()
 		Necrosis:ButtonSetup()
 

--- a/Necrosis/Necrosis.lua
+++ b/Necrosis/Necrosis.lua
@@ -1068,7 +1068,7 @@ function Necrosis:BuildTooltip(button, Type, anchor, sens)
 			-- We display the name of the stone and the action that will produce the click on the button ||On affiche le nom de la pierre et l'action que produira le clic sur le bouton
 			-- And also the cooldown ||Et aussi le Temps de recharge
 			if Local.Stone.Soul.Mode == 1 or Local.Stone.Soul.Mode == 3 then
-				GameTooltip:AddLine(self.Spell[51].Mana.." Mana")
+				GameTooltip:AddLine(self.Spells[51].Mana.." Mana")
 			end
 			self:MoneyToggle()
 			NecrosisTooltip:SetBagItem(Local.Stone.Soul.Location[1], Local.Stone.Soul.Location[2])
@@ -1082,7 +1082,7 @@ function Necrosis:BuildTooltip(button, Type, anchor, sens)
 		elseif (Type == "Healthstone") then
 			-- Idem ||Idem
 			if Local.Stone.Health.Mode == 1 then
-				GameTooltip:AddLine(self.Spell[52].Mana.." Mana")
+				GameTooltip:AddLine(self.Spells[52].Mana.." Mana")
 			end
 			self:MoneyToggle()
 			NecrosisTooltip:SetBagItem(Local.Stone.Health.Location[1], Local.Stone.Health.Location[2])
@@ -1101,14 +1101,14 @@ function Necrosis:BuildTooltip(button, Type, anchor, sens)
 		elseif (Type == "Spellstone") then
 			-- Eadem ||Eadem
 			if Local.Stone.Spell.Mode == 1 then
-				GameTooltip:AddLine(self.Spell[53].Mana.." Mana")
+				GameTooltip:AddLine(self.Spells[53].Mana.." Mana")
 			end
 			GameTooltip:AddLine(self.TooltipData[Type].Text[Local.Stone.Spell.Mode])
 		-- Fire stone ||Pierre de feu
 		elseif (Type == "Firestone") then
 			-- Idem ||Idem
 			if Local.Stone.Fire.Mode == 1 then
-				GameTooltip:AddLine(self.Spell[54].Mana.." Mana")
+				GameTooltip:AddLine(self.Spells[54].Mana.." Mana")
 			end
 			GameTooltip:AddLine(self.TooltipData[Type].Text[Local.Stone.Fire.Mode])
 		end
@@ -1129,7 +1129,7 @@ function Necrosis:BuildTooltip(button, Type, anchor, sens)
 		GameTooltip:SetText(self.TooltipData[Type].Label.."          |CFF808080"..self.Spell[45].Rank.."|r")
 	-- ..... for other buffs and demons, the mana cost ... ||..... pour les autres buffs et démons, le coût en mana...
 	elseif (Type == "Enslave") then
-		GameTooltip:AddLine(self.Spell[35].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[35].Mana.." Mana")
 		if Local.Soulshard.Count == 0 then
 			GameTooltip:AddLine("|c00FF4444"..self.TooltipData.Main.Soulshard..Local.Soulshard.Count.."|r")
 		end
@@ -1148,46 +1148,46 @@ function Necrosis:BuildTooltip(button, Type, anchor, sens)
 
 	elseif (Type == "Armor") then
 		if self.Spell[31].ID then
-			GameTooltip:AddLine(self.Spell[31].Mana.." Mana")
+			GameTooltip:AddLine(self.Spells[31].Mana.." Mana")
 		else
-			GameTooltip:AddLine(self.Spell[36].Mana.." Mana")
+			GameTooltip:AddLine(self.Spells[36].Mana.." Mana")
 		end
 	elseif (Type == "FelArmor") then
-		GameTooltip:AddLine(self.Spell[47].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[47].Mana.." Mana")
 	elseif (Type == "Invisible") then
-		GameTooltip:AddLine(self.Spell[33].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[33].Mana.." Mana")
 	elseif (Type == "Aqua") then
-		GameTooltip:AddLine(self.Spell[32].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[32].Mana.." Mana")
 	elseif (Type == "Kilrogg") then
-		GameTooltip:AddLine(self.Spell[34].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[34].Mana.." Mana")
 	elseif (Type == "Banish") then
-		GameTooltip:AddLine(self.Spell[9].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[9].Mana.." Mana")
 		if self.Spell[9].Rank:find("2") then
 		GameTooltip:AddLine(self.TooltipData[Type].Text)
 		end
 	elseif (Type == "Weakness") then
-		GameTooltip:AddLine(self.Spell[23].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[23].Mana.." Mana")
 	elseif (Type == "Agony") then
-		GameTooltip:AddLine(self.Spell[22].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[22].Mana.." Mana")
 	elseif (Type == "Tongues") then
-		GameTooltip:AddLine(self.Spell[25].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[25].Mana.." Mana")
 	elseif (Type == "Exhaust") then
-		GameTooltip:AddLine(self.Spell[40].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[40].Mana.." Mana")
 	elseif (Type == "Elements") then
-		GameTooltip:AddLine(self.Spell[26].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[26].Mana.." Mana")
 	elseif (Type == "Doom") then
-		GameTooltip:AddLine(self.Spell[16].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[16].Mana.." Mana")
 	elseif (Type == "Corruption") then
-		GameTooltip:AddLine(self.Spell[14].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[14].Mana.." Mana")
 	elseif (Type == "TP") then
-		GameTooltip:AddLine(self.Spell[37].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[37].Mana.." Mana")
 		if Local.Soulshard.Count == 0 then
 			GameTooltip:AddLine("|c00FF4444"..self.TooltipData.Main.Soulshard..Local.Soulshard.Count.."|r")
 		end
 	elseif (Type == "SoulLink") then
-		GameTooltip:AddLine(self.Spell[38].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[38].Mana.." Mana")
 	elseif (Type == "ShadowProtection") then
-		GameTooltip:AddLine(self.Spell[43].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[43].Mana.." Mana")
 		if start2 > 0 and duration2 > 0 then
 			local seconde = duration2 - ( GetTime() - start2)
 			local affiche
@@ -1213,48 +1213,48 @@ function Necrosis:BuildTooltip(button, Type, anchor, sens)
 			GameTooltip:AddLine("Cooldown : "..affiche)
 		end
 	elseif (Type == "Imp") then
-		GameTooltip:AddLine(self.Spell[3].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[3].Mana.." Mana")
 		if not (start > 0 and duration > 0) then
 			GameTooltip:AddLine(self.TooltipData.DominationCooldown)
 		end
 
 	elseif (Type == "Voidwalker") then
-		GameTooltip:AddLine(self.Spell[4].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[4].Mana.." Mana")
 		if Local.Soulshard.Count == 0 then
 			GameTooltip:AddLine("|c00FF4444"..self.TooltipData.Main.Soulshard..Local.Soulshard.Count.."|r")
 		elseif not (start > 0 and duration > 0) then
 			GameTooltip:AddLine(self.TooltipData.DominationCooldown)
 		end
 	elseif (Type == "Succubus") then
-		GameTooltip:AddLine(self.Spell[5].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[5].Mana.." Mana")
 		if Local.Soulshard.Count == 0 then
 			GameTooltip:AddLine("|c00FF4444"..self.TooltipData.Main.Soulshard..Local.Soulshard.Count.."|r")
 		elseif not (start > 0 and duration > 0) then
 			GameTooltip:AddLine(self.TooltipData.DominationCooldown)
 		end
 	elseif (Type == "Felhunter") then
-		GameTooltip:AddLine(self.Spell[6].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[6].Mana.." Mana")
 		if Local.Soulshard.Count == 0 then
 			GameTooltip:AddLine("|c00FF4444"..self.TooltipData.Main.Soulshard..Local.Soulshard.Count.."|r")
 		elseif not (start > 0 and duration > 0) then
 			GameTooltip:AddLine(self.TooltipData.DominationCooldown)
 		end
 	elseif (Type == "Felguard") then
-		GameTooltip:AddLine(self.Spell[7].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[7].Mana.." Mana")
 		if Local.Soulshard.Count == 0 then
 			GameTooltip:AddLine("|c00FF4444"..self.TooltipData.Main.Soulshard..Local.Soulshard.Count.."|r")
 		elseif not (start > 0 and duration > 0) then
 			GameTooltip:AddLine(self.TooltipData.DominationCooldown)
 		end
 	elseif (Type == "Infernal") then
-		GameTooltip:AddLine(self.Spell[8].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[8].Mana.." Mana")
 		if Local.Reagent.Infernal == 0 then
 			GameTooltip:AddLine("|c00FF4444"..self.TooltipData.Main.InfernalStone..Local.Reagent.Infernal.."|r")
 		else
 			GameTooltip:AddLine(self.TooltipData.Main.InfernalStone..Local.Reagent.Infernal)
 		end
 	elseif (Type == "Doomguard") then
-		GameTooltip:AddLine(self.Spell[30].Mana.." Mana")
+		GameTooltip:AddLine(self.Spells[30].Mana.." Mana")
 		if DemoniacStone == 0 then
 			GameTooltip:AddLine("|c00FF4444"..self.TooltipData.Main.DemoniacStone..Local.Reagent.Demoniac.."|r")
 		else
@@ -1507,7 +1507,7 @@ function Necrosis:UpdateMana()
 	-- If shadow guardian cooldown we gray || Si cooldown de gardien de l'ombre on grise
 	if _G["NecrosisBuffMenu8"] and self.Spell[43].ID then
 		local start, duration = GetSpellCooldown(self.Spell[43].ID, "spell")
-		if self.Spell[43].Mana > mana and start > 0 and duration > 0 then
+		if self.Spells[43].Mana > mana and start > 0 and duration > 0 then
 			if not Local.Desatured["Gardien"] then
 				NecrosisBuffMenu8:GetNormalTexture():SetDesaturated(1)
 				Local.Desatured["Gardien"] = true
@@ -1531,21 +1531,21 @@ function Necrosis:UpdateMana()
 	-- Coloring the button in gray if not enough mana || Coloration du bouton en grisé si pas assez de mana
 		if self.Spell[3].ID then
 
-			if self.Spell[3].Mana > mana then
+			if self.Spells[3].Mana > mana then
 				for i = 1, 7, 1 do
 					ManaPet[i] = false
 				end
 			elseif self.Spell[4].ID then
-				if self.Spell[4].Mana > mana then
+				if self.Spells[4].Mana > mana then
 					for i = 2, 7, 1 do
 						ManaPet[i] = false
 					end
 				elseif self.Spell[8].ID then
-					if self.Spell[8].Mana > mana then
+					if self.Spells[8].Mana > mana then
 							ManaPet[7] = false
 							ManaPet[8] = false
 					elseif self.Spell[30].ID then
-						if self.Spell[30].Mana > mana then
+						if self.Spells[30].Mana > mana then
 							ManaPet[8] = false
 						end
 					end
@@ -1607,7 +1607,7 @@ function Necrosis:UpdateMana()
 	if mana then
 	-- Coloring the button in gray if not enough mana || Coloration du bouton en grisé si pas assez de mana
 		if self.Spell[35].ID then
-			if self.Spell[35].Mana > mana or Local.Soulshard.Count == 0 then
+			if self.Spells[35].Mana > mana or Local.Soulshard.Count == 0 then
 				if not Local.Desatured["Enslave"] then
 					if _G["NecrosisPetMenu9"] then
 						NecrosisPetMenu9:GetNormalTexture():SetDesaturated(1)
@@ -1624,7 +1624,7 @@ function Necrosis:UpdateMana()
 			end
 		end
 		if _G["NecrosisBuffMenu1"] and self.Spell[31].ID then
-			if self.Spell[31].Mana > mana then
+			if self.Spells[31].Mana > mana then
 				if  not Local.Desatured["Armor"] then
 					NecrosisBuffMenu1:GetNormalTexture():SetDesaturated(1)
 					Local.Desatured["Armor"] = true
@@ -1636,7 +1636,7 @@ function Necrosis:UpdateMana()
 				end
 			end
 		elseif _G["NecrosisBuffMenu1"] and self.Spell[36].ID then
-			if self.Spell[36].Mana > mana then
+			if self.Spells[36].Mana > mana then
 				if not Local.Desatured["Armor"] then
 					NecrosisBuffMenu1:GetNormalTexture():SetDesaturated(1)
 					Local.Desatured["Armor"] = true
@@ -1648,7 +1648,7 @@ function Necrosis:UpdateMana()
 				end
 			end
 		elseif _G["NecrosisBuffMenu7"] and self.Spell[38].ID and not Local.BuffActif.SoulLink then
-			if self.Spell[38].Mana > mana then
+			if self.Spells[38].Mana > mana then
 				if not Local.Desatured["SoulLink"] then
 					NecrosisBuffMenu7:GetNormalTexture():SetDesaturated(1)
 					Local.Desatured["SoulLink"] = true
@@ -1670,7 +1670,7 @@ function Necrosis:UpdateMana()
 		for i = 1, #SortNumber, 1 do
 			local f = _G["NecrosisBuffMenu"..BoutonNumber[i]]
 			if f and self.Spell[SortNumber[i]].ID then
-				if self.Spell[SortNumber[i]].Mana > mana then
+				if self.Spells[SortNumber[i]].Mana > mana then
 					if not Local.Desatured["NecrosisBuffMenu"..BoutonNumber[i]] then
 						f:GetNormalTexture():SetDesaturated(1)
 						Local.Desatured["NecrosisBuffMenu"..BoutonNumber[i]] = true
@@ -1720,7 +1720,7 @@ function Necrosis:UpdateMana()
 		for i = 1, #SpellMana, 1 do
 			local f = _G["NecrosisCurseMenu"..i+1]
 			if f and self.Spell[SpellMana[i]].ID then
-				if self.Spell[SpellMana[i]].Mana > mana then
+				if self.Spells[SpellMana[i]].Mana > mana then
 					if not Local.Desatured["NecrosisCurseMenu"..i+1] then
 						f:GetNormalTexture():SetDesaturated(1)
 						Local.Desatured["NecrosisCurseMenu"..i+1] = true

--- a/Necrosis/Necrosis.lua
+++ b/Necrosis/Necrosis.lua
@@ -103,6 +103,7 @@ local metatable = {
 
 -- Create the spell metatable. || Création de la métatable contenant les sorts de nécrosis
 Necrosis.Spell = setmetatable({}, metatable)
+Necrosis.SpellRef = setmetatable({}, metatable)
 
 ------------------------------------------------------------------------------------------------------
 -- DECLARATION OF VARIABLES || DÉCLARATION DES VARIABLES

--- a/Necrosis/Necrosis.lua
+++ b/Necrosis/Necrosis.lua
@@ -344,8 +344,8 @@ function Necrosis:OnLoad(event)
 			for index in ipairs(Necrosis.Spell) do
 				Necrosis.Spell[index].ID = nil
 			end
-			Necrosis:SpellSetup()
 			Necrosis:CreateSpellList()
+			Necrosis:SpellSetup()
 			-- Necrosis:CreateMenu()
 			Necrosis:ButtonSetup()
 		end
@@ -599,8 +599,8 @@ function Necrosis:OnEvent(self, event,...)
 		for index in ipairs(Necrosis.Spell) do
 			Necrosis.Spell[index].ID = nil
 		end
-		Necrosis:SpellSetup()
 		Necrosis:CreateSpellList()
+		Necrosis:SpellSetup()
 		Necrosis:CreateMenu()
 		Necrosis:ButtonSetup()
 

--- a/Necrosis/Spells.lua
+++ b/Necrosis/Spells.lua
@@ -328,9 +328,11 @@ function Necrosis:CreateSpellList()
 		self.Spells[i] = {}
 		for index, value in pairs(self.SpellRef[i]) do
 			if IsSpellKnown(value) then
-				local Name, Rank = GetSpellInfo(value)
+				local Name = GetSpellInfo(value)
+				local Rank = GetSpellSubtext(value)
 				self.Spells[i].Name = Name
 				self.Spells[i].spellId = value
+				self.Spells[i].Rank = Rank
 				break
 			end
 		end

--- a/Necrosis/Spells.lua
+++ b/Necrosis/Spells.lua
@@ -329,10 +329,10 @@ function Necrosis:CreateSpellList()
 		for index, value in pairs(self.SpellRef[i]) do
 			if IsSpellKnown(value) then
 				local Name = GetSpellInfo(value)
-				local Rank = GetSpellSubtext(value)
 				self.Spells[i].Name = Name
+				self.Spells[i].Mana = self:GetManaCost(value)
 				self.Spells[i].spellId = value
-				self.Spells[i].Rank = Rank
+				self.Spells[i].Rank = GetSpellSubtext(value)
 				break
 			end
 		end
@@ -340,4 +340,14 @@ function Necrosis:CreateSpellList()
 	-- for i= 1, #self.Spell, 1 do
 		-- self:Msg(self.Spell[i].Name .. tostring(self.Spell[i].ID), "USER")
 	-- end
+end
+
+function Necrosis:GetManaCost(spellId)
+	local costs = GetSpellPowerCost(spellId)
+	for i, ressource in pairs(costs) do
+		if ressource.name == "MANA" then
+			return ressource.cost
+		end
+	end
+	return 0
 end

--- a/Necrosis/Spells.lua
+++ b/Necrosis/Spells.lua
@@ -257,3 +257,65 @@ function Necrosis:SpellLocalize(tooltip)
 	del(colorCode)
 	del(buttonName)
 end
+
+self.spellRefs = {
+	[1] = {5784}, -- Felsteed
+	[2] = {23161}, -- Dreadsteed
+	[3] = {688}, -- Imp || Diablotin 
+	[4] = {697}, -- Voidwalker || Marcheur
+	[5] = {712}, -- Succubus || Succube
+	[6] = {691}, -- Fellhunter
+	[7] = {691}, -- Felguard -- Fellhunter now
+	[8] = {1122}, -- Infernal
+	[9] = {18647,710}, -- Banish
+	[10] = {11726,11725,1098}, -- Enslave
+	[11] = {20765,20764,20763,20762,20707}, -- Soulstone Resurrection || Résurrection de pierre d'ame
+	[12] = {25309,11668,11667,11665,2941,1094,707,348}, -- Immolate
+	[13] = {Name = GetSpellInfo(6215),	Mana = 50,				Length = 15,	Type = 6}, -- Fear
+	[14] = {Name = GetSpellInfo(6222),	Mana = 50,				Length = 18,	Type = 5}, -- Corruption
+	[15] = {Name = GetSpellInfo(18708),	Mana = 50,				Length = 180,	Type = 3}, -- Fel Domination || Domination corrompue
+	[16] = {Name = GetSpellInfo(603),	Mana = 50,				Length = 60,	Type = 3}, -- Curse of Doom || Malédiction funeste
+	[17] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 20,	Type = 3}, -- NOPE NOT IN Classic Shadowfury || Furie de l'ombre
+	[18] = {Name = GetSpellInfo(17924),	Mana = 50,				Length = 60,	Type = 3}, -- Soul Fire || Feu de l'âme
+	[19] = {Name = GetSpellInfo(17926),	Mana = 50,				Length = 120,	Type = 3}, -- Death Coil || Voile mortel
+	[20] = {Name = GetSpellInfo(18871),	Mana = 50,				Length = 15,	Type = 3}, -- Shadowburn || Brûlure de l'ombre
+	[21] = {Name = GetSpellInfo(18932),	Mana = 50,				Length = 10,	Type = 3}, -- Conflagration
+	[22] = {Name = GetSpellInfo(11713),	Mana = 50,				Length = 24,	Type = 4}, -- Curse of Agony || Malédiction Agonie
+	[23] = {Name = GetSpellInfo(11708),	Mana = 50,				Length = 120,	Type = 4}, -- Curse of Weakness || Malédiction Faiblesse
+	[24] = {Name = GetSpellInfo(11717),	Mana = 0 ,              Length = 0,	    Type = 0}, -- Curse of Recklessness - removed in patch 3.1 || Malédiction Témérité || 
+	[25] = {Name = GetSpellInfo(11719),	Mana = 50,				Length = 30,	Type = 4}, -- Curse of Tongues || Malédiction Langage
+	[26] = {Name = GetSpellInfo(11722),	Mana = 50,				Length = 300,	Type = 4}, -- Curse of the Elements || Malédiction Eléments
+	[27] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 180,	Type = 3}, -- NOPE NOT IN Classic  Metamorphosis || Metamorphose
+	[28] = {Name = GetSpellInfo(18881),	Mana = 50,				Length = 30,	Type = 6}, -- Siphon Life || Syphon de vie
+	[29] = {Name = GetSpellInfo(17928),	Mana = 50,				Length = 40,	Type = 3}, -- Howl of Terror || Hurlement de terreur
+	[30] = {Name = GetSpellInfo(18540),	Mana = 50,				Length = 1800,	Type = 3}, -- Ritual of Doom || Rituel funeste
+	[31] = {Name = GetSpellInfo(11735),	Mana = 50,				Length = 0,		Type = 0}, -- Demon Armor || Armure démoniaque
+	[32] = {Name = GetSpellInfo(5697),	Mana = 50,				Length = 600,		Type = 0}, -- Unending Breath || Respiration interminable
+	[33] = {Name = GetSpellInfo(132),	Mana = 50,				Length = 0,		Type = 0}, -- Detect Invisibility || Détection de l'invisibilité
+	[34] = {Name = GetSpellInfo(126),	Mana = 50,				Length = 0,		Type = 0}, -- Eye of Kilrogg
+	[35] = {Name = GetSpellInfo(1098),	Mana = 50,				Length = 0,		Type = 0}, -- Enslave Demon
+	[36] = {Name = GetSpellInfo(696),	Mana = 50,				Length = 0,		Type = 0}, -- Demon Skin || Peau de démon 
+	[37] = {Name = GetSpellInfo(698),	Mana = 50,				Length = 120,		Type = 3}, -- Ritual of Summoning || Rituel d'invocation
+	[38] = {Name = GetSpellInfo(19028),	Mana = 50,				Length = 0,		Type = 0}, -- Soul Link || Lien spirituel
+	[39] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 45,		Type = 3}, -- NOPE NOT IN Classic  Demon Charge || Charge démoniaque
+	[40] = {Name = GetSpellInfo(18223),	Mana = 50,				Length = 12,	Type = 4}, -- Curse of Exhaustion || Malédiction de fatigue
+	[41] = {Name = GetSpellInfo(11689),	Mana = 50,				Length = 0,	     Type = 0}, -- Life Tap || Connexion
+	[42] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 12,	Type = 2}, -- NOPE NOT IN Classic  Haunt || Hanter
+	[43] = {Name = GetSpellInfo(28610),	Mana = 50,				Length = 30,	Type = 0}, -- Shadow Ward || Gardien de l'ombre
+	[44] = {Name = GetSpellInfo(19443),	Mana = 50,				Length = 60,	Type = 3}, -- Sacrifice || Sacrifice démoniaque 
+	[45] = {Name = GetSpellInfo(11661),	Mana = 50,				Length = 0,		Type = 0}, -- Shadow Bolt
+	[46] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 18,	Type = 6}, -- NOPE NOT IN Classic  Unstable Affliction || Affliction instable
+	[47] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 0,		Type = 0}, -- NOPE NOT IN Classic  Fel Armor || Gangrarmure
+	[48] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 18,	Type = 5}, -- NOPE NOT IN Classic  Seed of Corruption || Graine de Corruption
+	[49] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 180,	Type = 3}, -- NOPE NOT IN Classic SoulShatter || Brise âme
+	[50] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 300,	Type = 3}, -- NOPE NOT IN Classic Ritual of Souls || Rituel des âmes
+	[51] = {Name = GetSpellInfo(20755),	Mana = 50,				Length = 0,		Type = 0}, -- Create Soulstone || Création pierre d'âme
+	[52] = {Name = GetSpellInfo(5699),	Mana = 50,				Length = 0,		Type = 0}, -- Create Healthstone || Création pierre de soin
+	[53] = {Name = GetSpellInfo(2362),	Mana = 50,				Length = 0,		Type = 0}, -- Create Spellstone || Création pierre de sort
+	[54] = {Name = GetSpellInfo(17951),	Mana = 50,				Length = 0,		Type = 0}, -- Create Firestone || Création pierre de feu
+	[55] = {Name = GetSpellInfo(18938),	Mana = 50,				Length = 0,		Type = 0}, -- Dark Pact || Pacte noir
+	[56] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 0,		Type = 0}, -- NOPE NOT IN Classic  Shadow Cleave || Enchainement d'ombre
+	[57] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 30,	Type = 3}, -- NOPE NOT IN Classic  Immolation Aura || Aura d'immolation
+	[58] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 15,	Type = 3}, --  NOPE NOT IN Classic Challenging Howl || Hurlement de défi
+	[59] = {Name = GetSpellInfo(133),	Mana = 50,			    Length = 60,	Type = 3} --NOPE NOT IN Classic   Demonic Empowerment || Renforcement démoniaque
+}

--- a/Necrosis/Spells.lua
+++ b/Necrosis/Spells.lua
@@ -258,65 +258,80 @@ function Necrosis:SpellLocalize(tooltip)
 	del(buttonName)
 end
 
-self.spellRefs = {
-	[1] = {5784},													-- Felsteed
-	[2] = {23161},													-- Dreadsteed
-	[3] = {688},													-- Imp || Diablotin 
-	[4] = {697},													-- Voidwalker || Marcheur
-	[5] = {712},													-- Succubus || Succube
-	[6] = {691},													-- Fellhunter
-	[7] = {691},													-- Felguard -- Fellhunter now
-	[8] = {1122},													-- Infernal
-	[9] = {18647,710},												-- Banish
-	[10] = {11726,11725,1098},										-- Enslave
-	[11] = {20765,20764,20763,20762,20707},							-- Soulstone Resurrection || Résurrection de pierre d'ame
-	[12] = {25309,11668,11667,11665,2941,1094,707,348},				-- Immolate
-	[13] = {6215,6213,5782},										-- Fear
-	[14] = {25311,11672,11671,7648,6223,6222,172},					-- Corruption
-	[15] = {18708},													-- Fel Domination || Domination corrompue
-	[16] = {603},													-- Curse of Doom || Malédiction funeste
-	[17] = {},														-- NOPE NOT IN Classic Shadowfury || Furie de l'ombre
-	[18] = {17924,6353},											-- Soul Fire || Feu de l'âme
-	[19] = {17926,17925,6789},										-- Death Coil || Voile mortel
-	[20] = {18871,18870,18869,18868,18867,17877},					-- Shadowburn || Brûlure de l'ombre
-	[21] = {18932,18931,18930,17962},								-- Conflagration
-	[22] = {11713,11712,11711,6217,1014,980},						-- Curse of Agony || Malédiction Agonie
-	[23] = {11708,11707,7646,6205,1108,702},						-- Curse of Weakness || Malédiction Faiblesse
-	[24] = {11717,7659,7658,704},									-- Curse of Recklessness - removed in patch 3.1 || Malédiction Témérité || 
-	[25] = {11719,1714},											-- Curse of Tongues || Malédiction Langage
-	[26] = {11722,11721,1490},										-- Curse of the Elements || Malédiction Eléments
-	[27] = {},														-- NOPE NOT IN Classic  Metamorphosis || Metamorphose
-	[28] = {18881,18880,18879,18265},								-- Siphon Life || Syphon de vie
-	[29] = {17928,5484},											-- Howl of Terror || Hurlement de terreur
-	[30] = {18540},													-- Ritual of Doom || Rituel funeste
-	[31] = {11735,11734,11733,1086,706},							-- Demon Armor || Armure démoniaque
-	[32] = {5697},													-- Unending Breath || Respiration interminable
-	[33] = {11743,2970,132},										-- Detect Invisibility || Détection de l'invisibilité
-	[34] = {126},													-- Eye of Kilrogg
-	[35] = {11726,11725,1098},										-- Enslave Demon
-	[36] = {696,687},												-- Demon Skin || Peau de démon 
-	[37] = {698},													-- Ritual of Summoning || Rituel d'invocation
-	[38] = {19028},													-- Soul Link || Lien spirituel
-	[39] = {},														-- NOPE NOT IN Classic  Demon Charge || Charge démoniaque
-	[40] = {18223},													-- Curse of Exhaustion || Malédiction de fatigue
-	[41] = {11689,11688,11687,1456,1455,1454},						-- Life Tap || Connexion
-	[42] = {},														-- NOPE NOT IN Classic  Haunt || Hanter
-	[43] = {28610,11740,11739,6229},								-- Shadow Ward || Gardien de l'ombre
-	--[44] = {Name = GetSpellInfo(19443),	Mana = 50,						Length = 60,	Type = 3}, -- Sacrifice || Sacrifice démoniaque 
-	[44] = {18788},													-- Sacrifice || Sacrifice démoniaque 
-	[45] = {25307,11661,11660,11659,7641,1106,1088,705,695,686},	-- Shadow Bolt
-	[46] = {},														-- NOPE NOT IN Classic  Unstable Affliction || Affliction instable
-	[47] = {},														-- NOPE NOT IN Classic  Fel Armor || Gangrarmure
-	[48] = {},														-- NOPE NOT IN Classic  Seed of Corruption || Graine de Corruption
-	[49] = {},														-- NOPE NOT IN Classic SoulShatter || Brise âme
-	[50] = {},														-- NOPE NOT IN Classic Ritual of Souls || Rituel des âmes
-	[51] = {20757,20756,20755,20752,693},							-- Create Soulstone || Création pierre d'âme
-	[52] = {11730,11729,5699,6202,6201},							-- Create Healthstone || Création pierre de soin
-	[53] = {17728,17727,2362},										-- Create Spellstone || Création pierre de sort
-	[54] = {17953,17952,17951,6366},								-- Create Firestone || Création pierre de feu
-	[55] = {18938,18937,18220},										-- Dark Pact || Pacte noir
-	[56] = {},														-- NOPE NOT IN Classic  Shadow Cleave || Enchainement d'ombre
-	[57] = {},														-- NOPE NOT IN Classic  Immolation Aura || Aura d'immolation
-	[58] = {},														-- NOPE NOT IN Classic  Challenging Howl || Hurlement de défi
-	[59] = {}														--NOPE NOT IN Classic   Demonic Empowerment || Renforcement démoniaque
-}
+function Necrosis:CreateSpellList()
+-- ref all spells ordered by decreasing ranks (higher to lower)
+	self.SpellRef = {
+		[1] = {5784},													-- Felsteed
+		[2] = {23161},													-- Dreadsteed
+		[3] = {688},													-- Imp || Diablotin 
+		[4] = {697},													-- Voidwalker || Marcheur
+		[5] = {712},													-- Succubus || Succube
+		[6] = {691},													-- Fellhunter
+		[7] = {691},													-- Felguard -- Fellhunter now
+		[8] = {1122},													-- Infernal
+		[9] = {18647,710},												-- Banish
+		[10] = {11726,11725,1098},										-- Enslave
+		[11] = {20765,20764,20763,20762,20707},							-- Soulstone Resurrection || Résurrection de pierre d'ame
+		[12] = {25309,11668,11667,11665,2941,1094,707,348},				-- Immolate
+		[13] = {6215,6213,5782},										-- Fear
+		[14] = {25311,11672,11671,7648,6223,6222,172},					-- Corruption
+		[15] = {18708},													-- Fel Domination || Domination corrompue
+		[16] = {603},													-- Curse of Doom || Malédiction funeste
+		[17] = {},														-- NOPE NOT IN Classic Shadowfury || Furie de l'ombre
+		[18] = {17924,6353},											-- Soul Fire || Feu de l'âme
+		[19] = {17926,17925,6789},										-- Death Coil || Voile mortel
+		[20] = {18871,18870,18869,18868,18867,17877},					-- Shadowburn || Brûlure de l'ombre
+		[21] = {18932,18931,18930,17962},								-- Conflagration
+		[22] = {11713,11712,11711,6217,1014,980},						-- Curse of Agony || Malédiction Agonie
+		[23] = {11708,11707,7646,6205,1108,702},						-- Curse of Weakness || Malédiction Faiblesse
+		[24] = {11717,7659,7658,704},									-- Curse of Recklessness - removed in patch 3.1 || Malédiction Témérité || 
+		[25] = {11719,1714},											-- Curse of Tongues || Malédiction Langage
+		[26] = {11722,11721,1490},										-- Curse of the Elements || Malédiction Eléments
+		[27] = {},														-- NOPE NOT IN Classic  Metamorphosis || Metamorphose
+		[28] = {18881,18880,18879,18265},								-- Siphon Life || Syphon de vie
+		[29] = {17928,5484},											-- Howl of Terror || Hurlement de terreur
+		[30] = {18540},													-- Ritual of Doom || Rituel funeste
+		[31] = {11735,11734,11733,1086,706},							-- Demon Armor || Armure démoniaque
+		[32] = {5697},													-- Unending Breath || Respiration interminable
+		[33] = {11743,2970,132},										-- Detect Invisibility || Détection de l'invisibilité
+		[34] = {126},													-- Eye of Kilrogg
+		[35] = {11726,11725,1098},										-- Enslave Demon
+		[36] = {696,687},												-- Demon Skin || Peau de démon 
+		[37] = {698},													-- Ritual of Summoning || Rituel d'invocation
+		[38] = {19028},													-- Soul Link || Lien spirituel
+		[39] = {},														-- NOPE NOT IN Classic  Demon Charge || Charge démoniaque
+		[40] = {18223},													-- Curse of Exhaustion || Malédiction de fatigue
+		[41] = {11689,11688,11687,1456,1455,1454},						-- Life Tap || Connexion
+		[42] = {},														-- NOPE NOT IN Classic  Haunt || Hanter
+		[43] = {28610,11740,11739,6229},								-- Shadow Ward || Gardien de l'ombre
+		[44] = {18788},													-- Sacrifice || Sacrifice démoniaque 
+		[45] = {25307,11661,11660,11659,7641,1106,1088,705,695,686},	-- Shadow Bolt
+		[46] = {},														-- NOPE NOT IN Classic  Unstable Affliction || Affliction instable
+		[47] = {},														-- NOPE NOT IN Classic  Fel Armor || Gangrarmure
+		[48] = {},														-- NOPE NOT IN Classic  Seed of Corruption || Graine de Corruption
+		[49] = {},														-- NOPE NOT IN Classic SoulShatter || Brise âme
+		[50] = {},														-- NOPE NOT IN Classic Ritual of Souls || Rituel des âmes
+		[51] = {20757,20756,20755,20752,693},							-- Create Soulstone || Création pierre d'âme
+		[52] = {11730,11729,5699,6202,6201},							-- Create Healthstone || Création pierre de soin
+		[53] = {17728,17727,2362},										-- Create Spellstone || Création pierre de sort
+		[54] = {17953,17952,17951,6366},								-- Create Firestone || Création pierre de feu
+		[55] = {18938,18937,18220},										-- Dark Pact || Pacte noir
+		[56] = {},														-- NOPE NOT IN Classic  Shadow Cleave || Enchainement d'ombre
+		[57] = {},														-- NOPE NOT IN Classic  Immolation Aura || Aura d'immolation
+		[58] = {},														-- NOPE NOT IN Classic  Challenging Howl || Hurlement de défi
+		[59] = {}														-- NOPE NOT IN Classic   Demonic Empowerment || Renforcement démoniaque
+	}
+
+	for i = 1, #self.SpellRef, 1 do
+		for index, value in pairs(self.SpellRef[i]) do
+			if IsSpellKnown(value) then
+				local Name, Rank = GetSpellInfo(value)
+--				self:Msg(tostring(value) .. " " .. Name .. " " .. tostring(IsSpellKnown(value)),"USER")
+				break
+			end
+		end
+	end
+	for i= 1, #self.Spell, 1 do
+		self:Msg(self.Spell[i].Name .. tostring(self.Spell[i].ID), "USER")
+	end
+end

--- a/Necrosis/Spells.lua
+++ b/Necrosis/Spells.lua
@@ -260,78 +260,82 @@ end
 
 function Necrosis:CreateSpellList()
 -- ref all spells ordered by decreasing ranks (higher to lower)
-	self.SpellRef = {
-		[1] = {5784},													-- Felsteed
-		[2] = {23161},													-- Dreadsteed
-		[3] = {688},													-- Imp || Diablotin 
-		[4] = {697},													-- Voidwalker || Marcheur
-		[5] = {712},													-- Succubus || Succube
-		[6] = {691},													-- Fellhunter
-		[7] = {691},													-- Felguard -- Fellhunter now
-		[8] = {1122},													-- Infernal
-		[9] = {18647,710},												-- Banish
-		[10] = {11726,11725,1098},										-- Enslave
-		[11] = {20765,20764,20763,20762,20707},							-- Soulstone Resurrection || Résurrection de pierre d'ame
-		[12] = {25309,11668,11667,11665,2941,1094,707,348},				-- Immolate
-		[13] = {6215,6213,5782},										-- Fear
-		[14] = {25311,11672,11671,7648,6223,6222,172},					-- Corruption
-		[15] = {18708},													-- Fel Domination || Domination corrompue
-		[16] = {603},													-- Curse of Doom || Malédiction funeste
-		[17] = {},														-- NOPE NOT IN Classic Shadowfury || Furie de l'ombre
-		[18] = {17924,6353},											-- Soul Fire || Feu de l'âme
-		[19] = {17926,17925,6789},										-- Death Coil || Voile mortel
-		[20] = {18871,18870,18869,18868,18867,17877},					-- Shadowburn || Brûlure de l'ombre
-		[21] = {18932,18931,18930,17962},								-- Conflagration
-		[22] = {11713,11712,11711,6217,1014,980},						-- Curse of Agony || Malédiction Agonie
-		[23] = {11708,11707,7646,6205,1108,702},						-- Curse of Weakness || Malédiction Faiblesse
-		[24] = {11717,7659,7658,704},									-- Curse of Recklessness - removed in patch 3.1 || Malédiction Témérité || 
-		[25] = {11719,1714},											-- Curse of Tongues || Malédiction Langage
-		[26] = {11722,11721,1490},										-- Curse of the Elements || Malédiction Eléments
-		[27] = {},														-- NOPE NOT IN Classic  Metamorphosis || Metamorphose
-		[28] = {18881,18880,18879,18265},								-- Siphon Life || Syphon de vie
-		[29] = {17928,5484},											-- Howl of Terror || Hurlement de terreur
-		[30] = {18540},													-- Ritual of Doom || Rituel funeste
-		[31] = {11735,11734,11733,1086,706},							-- Demon Armor || Armure démoniaque
-		[32] = {5697},													-- Unending Breath || Respiration interminable
-		[33] = {11743,2970,132},										-- Detect Invisibility || Détection de l'invisibilité
-		[34] = {126},													-- Eye of Kilrogg
-		[35] = {11726,11725,1098},										-- Enslave Demon
-		[36] = {696,687},												-- Demon Skin || Peau de démon 
-		[37] = {698},													-- Ritual of Summoning || Rituel d'invocation
-		[38] = {19028},													-- Soul Link || Lien spirituel
-		[39] = {},														-- NOPE NOT IN Classic  Demon Charge || Charge démoniaque
-		[40] = {18223},													-- Curse of Exhaustion || Malédiction de fatigue
-		[41] = {11689,11688,11687,1456,1455,1454},						-- Life Tap || Connexion
-		[42] = {},														-- NOPE NOT IN Classic  Haunt || Hanter
-		[43] = {28610,11740,11739,6229},								-- Shadow Ward || Gardien de l'ombre
-		[44] = {18788},													-- Sacrifice || Sacrifice démoniaque 
-		[45] = {25307,11661,11660,11659,7641,1106,1088,705,695,686},	-- Shadow Bolt
-		[46] = {},														-- NOPE NOT IN Classic  Unstable Affliction || Affliction instable
-		[47] = {},														-- NOPE NOT IN Classic  Fel Armor || Gangrarmure
-		[48] = {},														-- NOPE NOT IN Classic  Seed of Corruption || Graine de Corruption
-		[49] = {},														-- NOPE NOT IN Classic SoulShatter || Brise âme
-		[50] = {},														-- NOPE NOT IN Classic Ritual of Souls || Rituel des âmes
-		[51] = {20757,20756,20755,20752,693},							-- Create Soulstone || Création pierre d'âme
-		[52] = {11730,11729,5699,6202,6201},							-- Create Healthstone || Création pierre de soin
-		[53] = {17728,17727,2362},										-- Create Spellstone || Création pierre de sort
-		[54] = {17953,17952,17951,6366},								-- Create Firestone || Création pierre de feu
-		[55] = {18938,18937,18220},										-- Dark Pact || Pacte noir
-		[56] = {},														-- NOPE NOT IN Classic  Shadow Cleave || Enchainement d'ombre
-		[57] = {},														-- NOPE NOT IN Classic  Immolation Aura || Aura d'immolation
-		[58] = {},														-- NOPE NOT IN Classic  Challenging Howl || Hurlement de défi
-		[59] = {}														-- NOPE NOT IN Classic   Demonic Empowerment || Renforcement démoniaque
-	}
+	if (#self.SpellRef == 0) then
+		self.SpellRef = {
+			[1] = {5784},													-- Felsteed
+			[2] = {23161},													-- Dreadsteed
+			[3] = {688},													-- Imp || Diablotin 
+			[4] = {697},													-- Voidwalker || Marcheur
+			[5] = {712},													-- Succubus || Succube
+			[6] = {691},													-- Fellhunter
+			[7] = {691},													-- Felguard -- Fellhunter now
+			[8] = {1122},													-- Infernal
+			[9] = {18647,710},												-- Banish
+			[10] = {11726,11725,1098},										-- Enslave
+			[11] = {20765,20764,20763,20762,20707},							-- Soulstone Resurrection || Résurrection de pierre d'ame
+			[12] = {25309,11668,11667,11665,2941,1094,707,348},				-- Immolate
+			[13] = {6215,6213,5782},										-- Fear
+			[14] = {25311,11672,11671,7648,6223,6222,172},					-- Corruption
+			[15] = {18708},													-- Fel Domination || Domination corrompue
+			[16] = {603},													-- Curse of Doom || Malédiction funeste
+			[17] = {},														-- NOPE NOT IN Classic Shadowfury || Furie de l'ombre
+			[18] = {17924,6353},											-- Soul Fire || Feu de l'âme
+			[19] = {17926,17925,6789},										-- Death Coil || Voile mortel
+			[20] = {18871,18870,18869,18868,18867,17877},					-- Shadowburn || Brûlure de l'ombre
+			[21] = {18932,18931,18930,17962},								-- Conflagration
+			[22] = {11713,11712,11711,6217,1014,980},						-- Curse of Agony || Malédiction Agonie
+			[23] = {11708,11707,7646,6205,1108,702},						-- Curse of Weakness || Malédiction Faiblesse
+			[24] = {11717,7659,7658,704},									-- Curse of Recklessness - removed in patch 3.1 || Malédiction Témérité || 
+			[25] = {11719,1714},											-- Curse of Tongues || Malédiction Langage
+			[26] = {11722,11721,1490},										-- Curse of the Elements || Malédiction Eléments
+			[27] = {},														-- NOPE NOT IN Classic  Metamorphosis || Metamorphose
+			[28] = {18881,18880,18879,18265},								-- Siphon Life || Syphon de vie
+			[29] = {17928,5484},											-- Howl of Terror || Hurlement de terreur
+			[30] = {18540},													-- Ritual of Doom || Rituel funeste
+			[31] = {11735,11734,11733,1086,706},							-- Demon Armor || Armure démoniaque
+			[32] = {5697},													-- Unending Breath || Respiration interminable
+			[33] = {11743,2970,132},										-- Detect Invisibility || Détection de l'invisibilité
+			[34] = {126},													-- Eye of Kilrogg
+			[35] = {11726,11725,1098},										-- Enslave Demon
+			[36] = {696,687},												-- Demon Skin || Peau de démon 
+			[37] = {698},													-- Ritual of Summoning || Rituel d'invocation
+			[38] = {19028},													-- Soul Link || Lien spirituel
+			[39] = {},														-- NOPE NOT IN Classic  Demon Charge || Charge démoniaque
+			[40] = {18223},													-- Curse of Exhaustion || Malédiction de fatigue
+			[41] = {11689,11688,11687,1456,1455,1454},						-- Life Tap || Connexion
+			[42] = {},														-- NOPE NOT IN Classic  Haunt || Hanter
+			[43] = {28610,11740,11739,6229},								-- Shadow Ward || Gardien de l'ombre
+			[44] = {18788},													-- Sacrifice || Sacrifice démoniaque 
+			[45] = {25307,11661,11660,11659,7641,1106,1088,705,695,686},	-- Shadow Bolt
+			[46] = {},														-- NOPE NOT IN Classic  Unstable Affliction || Affliction instable
+			[47] = {},														-- NOPE NOT IN Classic  Fel Armor || Gangrarmure
+			[48] = {},														-- NOPE NOT IN Classic  Seed of Corruption || Graine de Corruption
+			[49] = {},														-- NOPE NOT IN Classic SoulShatter || Brise âme
+			[50] = {},														-- NOPE NOT IN Classic Ritual of Souls || Rituel des âmes
+			[51] = {20757,20756,20755,20752,693},							-- Create Soulstone || Création pierre d'âme
+			[52] = {11730,11729,5699,6202,6201},							-- Create Healthstone || Création pierre de soin
+			[53] = {17728,17727,2362},										-- Create Spellstone || Création pierre de sort
+			[54] = {17953,17952,17951,6366},								-- Create Firestone || Création pierre de feu
+			[55] = {18938,18937,18220},										-- Dark Pact || Pacte noir
+			[56] = {},														-- NOPE NOT IN Classic  Shadow Cleave || Enchainement d'ombre
+			[57] = {},														-- NOPE NOT IN Classic  Immolation Aura || Aura d'immolation
+			[58] = {},														-- NOPE NOT IN Classic  Challenging Howl || Hurlement de défi
+			[59] = {}														-- NOPE NOT IN Classic   Demonic Empowerment || Renforcement démoniaque
+		}
+	end
 
 	for i = 1, #self.SpellRef, 1 do
+		self.Spells[i] = {}
 		for index, value in pairs(self.SpellRef[i]) do
 			if IsSpellKnown(value) then
 				local Name, Rank = GetSpellInfo(value)
---				self:Msg(tostring(value) .. " " .. Name .. " " .. tostring(IsSpellKnown(value)),"USER")
+				self.Spells[i].Name = Name
+				self.Spells[i].spellId = value
 				break
 			end
 		end
 	end
-	for i= 1, #self.Spell, 1 do
-		self:Msg(self.Spell[i].Name .. tostring(self.Spell[i].ID), "USER")
-	end
+	-- for i= 1, #self.Spell, 1 do
+		-- self:Msg(self.Spell[i].Name .. tostring(self.Spell[i].ID), "USER")
+	-- end
 end

--- a/Necrosis/Spells.lua
+++ b/Necrosis/Spells.lua
@@ -259,63 +259,64 @@ function Necrosis:SpellLocalize(tooltip)
 end
 
 self.spellRefs = {
-	[1] = {5784}, -- Felsteed
-	[2] = {23161}, -- Dreadsteed
-	[3] = {688}, -- Imp || Diablotin 
-	[4] = {697}, -- Voidwalker || Marcheur
-	[5] = {712}, -- Succubus || Succube
-	[6] = {691}, -- Fellhunter
-	[7] = {691}, -- Felguard -- Fellhunter now
-	[8] = {1122}, -- Infernal
-	[9] = {18647,710}, -- Banish
-	[10] = {11726,11725,1098}, -- Enslave
-	[11] = {20765,20764,20763,20762,20707}, -- Soulstone Resurrection || Résurrection de pierre d'ame
-	[12] = {25309,11668,11667,11665,2941,1094,707,348}, -- Immolate
-	[13] = {Name = GetSpellInfo(6215),	Mana = 50,				Length = 15,	Type = 6}, -- Fear
-	[14] = {Name = GetSpellInfo(6222),	Mana = 50,				Length = 18,	Type = 5}, -- Corruption
-	[15] = {Name = GetSpellInfo(18708),	Mana = 50,				Length = 180,	Type = 3}, -- Fel Domination || Domination corrompue
-	[16] = {Name = GetSpellInfo(603),	Mana = 50,				Length = 60,	Type = 3}, -- Curse of Doom || Malédiction funeste
-	[17] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 20,	Type = 3}, -- NOPE NOT IN Classic Shadowfury || Furie de l'ombre
-	[18] = {Name = GetSpellInfo(17924),	Mana = 50,				Length = 60,	Type = 3}, -- Soul Fire || Feu de l'âme
-	[19] = {Name = GetSpellInfo(17926),	Mana = 50,				Length = 120,	Type = 3}, -- Death Coil || Voile mortel
-	[20] = {Name = GetSpellInfo(18871),	Mana = 50,				Length = 15,	Type = 3}, -- Shadowburn || Brûlure de l'ombre
-	[21] = {Name = GetSpellInfo(18932),	Mana = 50,				Length = 10,	Type = 3}, -- Conflagration
-	[22] = {Name = GetSpellInfo(11713),	Mana = 50,				Length = 24,	Type = 4}, -- Curse of Agony || Malédiction Agonie
-	[23] = {Name = GetSpellInfo(11708),	Mana = 50,				Length = 120,	Type = 4}, -- Curse of Weakness || Malédiction Faiblesse
-	[24] = {Name = GetSpellInfo(11717),	Mana = 0 ,              Length = 0,	    Type = 0}, -- Curse of Recklessness - removed in patch 3.1 || Malédiction Témérité || 
-	[25] = {Name = GetSpellInfo(11719),	Mana = 50,				Length = 30,	Type = 4}, -- Curse of Tongues || Malédiction Langage
-	[26] = {Name = GetSpellInfo(11722),	Mana = 50,				Length = 300,	Type = 4}, -- Curse of the Elements || Malédiction Eléments
-	[27] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 180,	Type = 3}, -- NOPE NOT IN Classic  Metamorphosis || Metamorphose
-	[28] = {Name = GetSpellInfo(18881),	Mana = 50,				Length = 30,	Type = 6}, -- Siphon Life || Syphon de vie
-	[29] = {Name = GetSpellInfo(17928),	Mana = 50,				Length = 40,	Type = 3}, -- Howl of Terror || Hurlement de terreur
-	[30] = {Name = GetSpellInfo(18540),	Mana = 50,				Length = 1800,	Type = 3}, -- Ritual of Doom || Rituel funeste
-	[31] = {Name = GetSpellInfo(11735),	Mana = 50,				Length = 0,		Type = 0}, -- Demon Armor || Armure démoniaque
-	[32] = {Name = GetSpellInfo(5697),	Mana = 50,				Length = 600,		Type = 0}, -- Unending Breath || Respiration interminable
-	[33] = {Name = GetSpellInfo(132),	Mana = 50,				Length = 0,		Type = 0}, -- Detect Invisibility || Détection de l'invisibilité
-	[34] = {Name = GetSpellInfo(126),	Mana = 50,				Length = 0,		Type = 0}, -- Eye of Kilrogg
-	[35] = {Name = GetSpellInfo(1098),	Mana = 50,				Length = 0,		Type = 0}, -- Enslave Demon
-	[36] = {Name = GetSpellInfo(696),	Mana = 50,				Length = 0,		Type = 0}, -- Demon Skin || Peau de démon 
-	[37] = {Name = GetSpellInfo(698),	Mana = 50,				Length = 120,		Type = 3}, -- Ritual of Summoning || Rituel d'invocation
-	[38] = {Name = GetSpellInfo(19028),	Mana = 50,				Length = 0,		Type = 0}, -- Soul Link || Lien spirituel
-	[39] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 45,		Type = 3}, -- NOPE NOT IN Classic  Demon Charge || Charge démoniaque
-	[40] = {Name = GetSpellInfo(18223),	Mana = 50,				Length = 12,	Type = 4}, -- Curse of Exhaustion || Malédiction de fatigue
-	[41] = {Name = GetSpellInfo(11689),	Mana = 50,				Length = 0,	     Type = 0}, -- Life Tap || Connexion
-	[42] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 12,	Type = 2}, -- NOPE NOT IN Classic  Haunt || Hanter
-	[43] = {Name = GetSpellInfo(28610),	Mana = 50,				Length = 30,	Type = 0}, -- Shadow Ward || Gardien de l'ombre
-	[44] = {Name = GetSpellInfo(19443),	Mana = 50,				Length = 60,	Type = 3}, -- Sacrifice || Sacrifice démoniaque 
-	[45] = {Name = GetSpellInfo(11661),	Mana = 50,				Length = 0,		Type = 0}, -- Shadow Bolt
-	[46] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 18,	Type = 6}, -- NOPE NOT IN Classic  Unstable Affliction || Affliction instable
-	[47] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 0,		Type = 0}, -- NOPE NOT IN Classic  Fel Armor || Gangrarmure
-	[48] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 18,	Type = 5}, -- NOPE NOT IN Classic  Seed of Corruption || Graine de Corruption
-	[49] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 180,	Type = 3}, -- NOPE NOT IN Classic SoulShatter || Brise âme
-	[50] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 300,	Type = 3}, -- NOPE NOT IN Classic Ritual of Souls || Rituel des âmes
-	[51] = {Name = GetSpellInfo(20755),	Mana = 50,				Length = 0,		Type = 0}, -- Create Soulstone || Création pierre d'âme
-	[52] = {Name = GetSpellInfo(5699),	Mana = 50,				Length = 0,		Type = 0}, -- Create Healthstone || Création pierre de soin
-	[53] = {Name = GetSpellInfo(2362),	Mana = 50,				Length = 0,		Type = 0}, -- Create Spellstone || Création pierre de sort
-	[54] = {Name = GetSpellInfo(17951),	Mana = 50,				Length = 0,		Type = 0}, -- Create Firestone || Création pierre de feu
-	[55] = {Name = GetSpellInfo(18938),	Mana = 50,				Length = 0,		Type = 0}, -- Dark Pact || Pacte noir
-	[56] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 0,		Type = 0}, -- NOPE NOT IN Classic  Shadow Cleave || Enchainement d'ombre
-	[57] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 30,	Type = 3}, -- NOPE NOT IN Classic  Immolation Aura || Aura d'immolation
-	[58] = {Name = GetSpellInfo(133),	Mana = 50,				Length = 15,	Type = 3}, --  NOPE NOT IN Classic Challenging Howl || Hurlement de défi
-	[59] = {Name = GetSpellInfo(133),	Mana = 50,			    Length = 60,	Type = 3} --NOPE NOT IN Classic   Demonic Empowerment || Renforcement démoniaque
+	[1] = {5784},													-- Felsteed
+	[2] = {23161},													-- Dreadsteed
+	[3] = {688},													-- Imp || Diablotin 
+	[4] = {697},													-- Voidwalker || Marcheur
+	[5] = {712},													-- Succubus || Succube
+	[6] = {691},													-- Fellhunter
+	[7] = {691},													-- Felguard -- Fellhunter now
+	[8] = {1122},													-- Infernal
+	[9] = {18647,710},												-- Banish
+	[10] = {11726,11725,1098},										-- Enslave
+	[11] = {20765,20764,20763,20762,20707},							-- Soulstone Resurrection || Résurrection de pierre d'ame
+	[12] = {25309,11668,11667,11665,2941,1094,707,348},				-- Immolate
+	[13] = {6215,6213,5782},										-- Fear
+	[14] = {25311,11672,11671,7648,6223,6222,172},					-- Corruption
+	[15] = {18708},													-- Fel Domination || Domination corrompue
+	[16] = {603},													-- Curse of Doom || Malédiction funeste
+	[17] = {},														-- NOPE NOT IN Classic Shadowfury || Furie de l'ombre
+	[18] = {17924,6353},											-- Soul Fire || Feu de l'âme
+	[19] = {17926,17925,6789},										-- Death Coil || Voile mortel
+	[20] = {18871,18870,18869,18868,18867,17877},					-- Shadowburn || Brûlure de l'ombre
+	[21] = {18932,18931,18930,17962},								-- Conflagration
+	[22] = {11713,11712,11711,6217,1014,980},						-- Curse of Agony || Malédiction Agonie
+	[23] = {11708,11707,7646,6205,1108,702},						-- Curse of Weakness || Malédiction Faiblesse
+	[24] = {11717,7659,7658,704},									-- Curse of Recklessness - removed in patch 3.1 || Malédiction Témérité || 
+	[25] = {11719,1714},											-- Curse of Tongues || Malédiction Langage
+	[26] = {11722,11721,1490},										-- Curse of the Elements || Malédiction Eléments
+	[27] = {},														-- NOPE NOT IN Classic  Metamorphosis || Metamorphose
+	[28] = {18881,18880,18879,18265},								-- Siphon Life || Syphon de vie
+	[29] = {17928,5484},											-- Howl of Terror || Hurlement de terreur
+	[30] = {18540},													-- Ritual of Doom || Rituel funeste
+	[31] = {11735,11734,11733,1086,706},							-- Demon Armor || Armure démoniaque
+	[32] = {5697},													-- Unending Breath || Respiration interminable
+	[33] = {11743,2970,132},										-- Detect Invisibility || Détection de l'invisibilité
+	[34] = {126},													-- Eye of Kilrogg
+	[35] = {11726,11725,1098},										-- Enslave Demon
+	[36] = {696,687},												-- Demon Skin || Peau de démon 
+	[37] = {698},													-- Ritual of Summoning || Rituel d'invocation
+	[38] = {19028},													-- Soul Link || Lien spirituel
+	[39] = {},														-- NOPE NOT IN Classic  Demon Charge || Charge démoniaque
+	[40] = {18223},													-- Curse of Exhaustion || Malédiction de fatigue
+	[41] = {11689,11688,11687,1456,1455,1454},						-- Life Tap || Connexion
+	[42] = {},														-- NOPE NOT IN Classic  Haunt || Hanter
+	[43] = {28610,11740,11739,6229},								-- Shadow Ward || Gardien de l'ombre
+	--[44] = {Name = GetSpellInfo(19443),	Mana = 50,						Length = 60,	Type = 3}, -- Sacrifice || Sacrifice démoniaque 
+	[44] = {18788},													-- Sacrifice || Sacrifice démoniaque 
+	[45] = {25307,11661,11660,11659,7641,1106,1088,705,695,686},	-- Shadow Bolt
+	[46] = {},														-- NOPE NOT IN Classic  Unstable Affliction || Affliction instable
+	[47] = {},														-- NOPE NOT IN Classic  Fel Armor || Gangrarmure
+	[48] = {},														-- NOPE NOT IN Classic  Seed of Corruption || Graine de Corruption
+	[49] = {},														-- NOPE NOT IN Classic SoulShatter || Brise âme
+	[50] = {},														-- NOPE NOT IN Classic Ritual of Souls || Rituel des âmes
+	[51] = {20757,20756,20755,20752,693},							-- Create Soulstone || Création pierre d'âme
+	[52] = {11730,11729,5699,6202,6201},							-- Create Healthstone || Création pierre de soin
+	[53] = {17728,17727,2362},										-- Create Spellstone || Création pierre de sort
+	[54] = {17953,17952,17951,6366},								-- Create Firestone || Création pierre de feu
+	[55] = {18938,18937,18220},										-- Dark Pact || Pacte noir
+	[56] = {},														-- NOPE NOT IN Classic  Shadow Cleave || Enchainement d'ombre
+	[57] = {},														-- NOPE NOT IN Classic  Immolation Aura || Aura d'immolation
+	[58] = {},														-- NOPE NOT IN Classic  Challenging Howl || Hurlement de défi
+	[59] = {}														--NOPE NOT IN Classic   Demonic Empowerment || Renforcement démoniaque
 }

--- a/Necrosis/XML/Attributes.lua
+++ b/Necrosis/XML/Attributes.lua
@@ -230,7 +230,7 @@ function Necrosis:PetSpellAttribute()
 			f:SetAttribute("type2", "macro")
 			f:SetAttribute("spell", self.Spells[i+1].Name)
 			f:SetAttribute("macrotext",
-				"/cast "..self.Spell[15].Name.."\n/stopcasting\n/cast "..self.Spells[i+1].Name
+				"/cast "..self.Spells[15].Name.."\n/stopcasting\n/cast "..self.Spells[i+1].Name
 			)
 		end
 	end
@@ -332,9 +332,9 @@ function Necrosis:MainButtonAttribute()
 		end
 	end
 
-	if Necrosis.Spell[NecrosisConfig.MainSpell].ID then
+	if Necrosis.Spells[NecrosisConfig.MainSpell].spellId then
 		NecrosisButton:SetAttribute("type1", "spell")
-		NecrosisButton:SetAttribute("spell", Necrosis.Spell[NecrosisConfig.MainSpell].ID)
+		NecrosisButton:SetAttribute("spell", Necrosis.Spells[NecrosisConfig.MainSpell].spellId)
 	end
 end
 

--- a/Necrosis/XML/Attributes.lua
+++ b/Necrosis/XML/Attributes.lua
@@ -151,10 +151,10 @@ function Necrosis:BuffSpellAttribute()
 	-- Association de l'armure demoniaque si le sort est disponible
 	if _G["NecrosisBuffMenu1"] then
 		NecrosisBuffMenu1:SetAttribute("type", "spell")
-		if not self.Spell[31].ID then
+		if not self.Spells[31].spellId then
 			NecrosisBuffMenu1:SetAttribute("spell", self.Spells[36].spellId)
 		else
-			 NecrosisBuffMenu1:SetAttribute("spell", self.Spells[31].spellId)
+			NecrosisBuffMenu1:SetAttribute("spell", self.Spells[31].spellId)
 		end
 	end
 
@@ -176,12 +176,12 @@ function Necrosis:BuffSpellAttribute()
 
 	-- Cas particulier : Bouton de Banish
 	if _G["NecrosisBuffMenu10"] then
-		local SpellName_Rank = self.Spell[9].Name.."("..self.Spell[9].Rank..")"
+		local SpellName_Rank = self.Spells[9].Name.."("..self.Spells[9].Rank..")"
 
 		NecrosisBuffMenu10:SetAttribute("unit*", "target")				-- associate left & right clicks with target
 		NecrosisBuffMenu10:SetAttribute("ctrl-unit*", "focus") 		-- associate CTRL+left or right clicks with focus
 
-		if self.Spell[9].Rank:find("1") then	-- the warlock can only do Banish(Rank 1) 
+		if self.Spells[9].Rank:find("1") then	-- the warlock can only do Banish(Rank 1) 
 			-- left & right click will perform the same macro
 			NecrosisBuffMenu10:SetAttribute("type*", "macro")
 			NecrosisBuffMenu10:SetAttribute("macrotext*", "/focus\n/cast "..SpellName_Rank)
@@ -192,7 +192,7 @@ function Necrosis:BuffSpellAttribute()
 			NecrosisBuffMenu10:SetAttribute("ctrl-spell*", SpellName_Rank)
 		end 
 
-		if self.Spell[9].Rank:find("2") then -- the warlock has Banish(rank 2)
+		if self.Spells[9].Rank:find("2") then -- the warlock has Banish(rank 2)
 			local Rank1 = SpellName_Rank:gsub("2", "1")
 			
 			-- so lets use the "harmbutton" special attribute!
@@ -226,15 +226,11 @@ function Necrosis:PetSpellAttribute()
 	for i = 2, 6, 1 do
 		local f = _G["NecrosisPetMenu"..i]
 		if f then
-			local SpellName_Rank = self.Spell[i+1].Name
-			if self.Spell[i+1].Rank and not (self.Spell[i+1].Rank == " ") then
-				SpellName_Rank = SpellName_Rank.."("..self.Spell[i+1].Rank..")"
-			end
 			f:SetAttribute("type1", "spell")
 			f:SetAttribute("type2", "macro")
-			f:SetAttribute("spell", SpellName_Rank)
+			f:SetAttribute("spell", self.Spells[i+1].Name)
 			f:SetAttribute("macrotext",
-				"/cast "..self.Spell[15].Name.."\n/stopcasting\n/cast "..SpellName_Rank
+				"/cast "..self.Spell[15].Name.."\n/stopcasting\n/cast "..self.Spells[i+1].Name
 			)
 		end
 	end
@@ -245,10 +241,6 @@ function Necrosis:PetSpellAttribute()
 	for i = 1, #buttonID, 1 do
 		local f = _G["NecrosisPetMenu"..buttonID[i]]
 		if f then
-			-- local SpellName_Rank = self.Spell[ BuffID[i] ].Name
-			-- if self.Spell[ BuffID[i] ].Rank and not (self.Spell[ BuffID[i] ].Rank == " ") then
-			-- 	SpellName_Rank = SpellName_Rank.."("..self.Spell[ BuffID[i] ].Rank..")"
-			-- end
 			f:SetAttribute("type", "spell")
 			f:SetAttribute("spell", self.Spells[ BuffID[i] ].spellId)
 		end
@@ -265,10 +257,6 @@ function Necrosis:CurseSpellAttribute()
 	for i = 1, #buffID, 1 do
 		local f = _G["NecrosisCurseMenu"..i]
 		if f then
-			-- local SpellName_Rank = self.Spell[ buffID[i] ].Name
-			-- if self.Spell[ buffID[i] ].Rank and not (self.Spell[ buffID[i] ].Rank == " ") then
-			-- 	SpellName_Rank = SpellName_Rank.."("..self.Spell[ buffID[i] ].Rank..")"
-			-- end
 			f:SetAttribute("harmbutton", "debuff")
 			f:SetAttribute("type-debuff", "spell")
 			f:SetAttribute("unit", "target")
@@ -304,7 +292,7 @@ function Necrosis:StoneAttribute(Steed)
 			local leftMountName = GetSpellInfo(NecrosisConfig.LeftMount)
 			NecrosisMountButton:SetAttribute("spell1", leftMountName)
 		else
-			if (self.Spell[2].ID) then
+			if (self.Spells[2].spellId) then
 				NecrosisMountButton:SetAttribute("spell1", self.Spells[2].spellId)
 				NecrosisMountButton:SetAttribute("spell2", self.Spells[1].spellId)
 			else
@@ -324,17 +312,9 @@ function Necrosis:StoneAttribute(Steed)
 	NecrosisSpellTimerButton:SetAttribute("macrotext", "/focus")
 	NecrosisSpellTimerButton:SetAttribute("type2", "item")
 	NecrosisSpellTimerButton:SetAttribute("item", self.Translation.Item.Hearthstone)
-
-	-- if the 'Ritual of Souls' spell is known, then associate it to the hearthstone shift-click.
-	-- Cas particulier : Si le sort du Rituel des âmes existe, on l'associe au shift+clic healthstone.
-	-- not in classic (TODO remove)
-	if _G["NecrosisHealthstoneButton"] and self.Spell[50].ID then
-		NecrosisHealthstoneButton:SetAttribute("shift-type*", "spell")
-		NecrosisHealthstoneButton:SetAttribute("shift-spell*", self.Spell[50].Name)
-	end
 	
 	-- if the 'Ritual of Summoning' spell is known, then associate it to the soulstone shift-click.
-	if _G["NecrosisSoulstoneButton"] and self.Spell[37].ID then
+	if _G["NecrosisSoulstoneButton"] and self.Spells[37].spellId then
 		NecrosisSoulstoneButton:SetAttribute("shift-type*", "spell")
 		NecrosisSoulstoneButton:SetAttribute("shift-spell*", self.Spells[37].spellId)
 	end
@@ -354,7 +334,7 @@ function Necrosis:MainButtonAttribute()
 
 	if Necrosis.Spell[NecrosisConfig.MainSpell].ID then
 		NecrosisButton:SetAttribute("type1", "spell")
-		NecrosisButton:SetAttribute("spell", Necrosis.Spell[NecrosisConfig.MainSpell].Name)
+		NecrosisButton:SetAttribute("spell", Necrosis.Spell[NecrosisConfig.MainSpell].ID)
 	end
 end
 

--- a/Necrosis/XML/Attributes.lua
+++ b/Necrosis/XML/Attributes.lua
@@ -152,13 +152,9 @@ function Necrosis:BuffSpellAttribute()
 	if _G["NecrosisBuffMenu1"] then
 		NecrosisBuffMenu1:SetAttribute("type", "spell")
 		if not self.Spell[31].ID then
-			NecrosisBuffMenu1:SetAttribute("spell",
-				self.Spell[36].Name.."("..self.Spell[36].Rank..")"
-			)
+			NecrosisBuffMenu1:SetAttribute("spell", self.Spells[36].spellId)
 		else
-			NecrosisBuffMenu1:SetAttribute("spell",
-				self.Spell[31].Name.."("..self.Spell[31].Rank..")"
-			)
+			 NecrosisBuffMenu1:SetAttribute("spell", self.Spells[31].spellId)
 		end
 	end
 
@@ -173,11 +169,7 @@ function Necrosis:BuffSpellAttribute()
 			if not (i == 2 or i == 5 or i == 7 or i == 8 or i == 9 or i == 10) then
 				f:SetAttribute("unit", "target")
 			end
-			local SpellName_Rank = self.Spell[ buffID[i] ].Name
-			if self.Spell[ buffID[i] ].Rank and not (self.Spell[ buffID[i] ].Rank == " ") then
-				SpellName_Rank = SpellName_Rank.."("..self.Spell[ buffID[i] ].Rank..")"
-			end
-			f:SetAttribute("spell", SpellName_Rank)
+			f:SetAttribute("spell", self.Spells[buffID[i]].spellId)
 		end
 	end
 
@@ -253,12 +245,12 @@ function Necrosis:PetSpellAttribute()
 	for i = 1, #buttonID, 1 do
 		local f = _G["NecrosisPetMenu"..buttonID[i]]
 		if f then
-			local SpellName_Rank = self.Spell[ BuffID[i] ].Name
-			if self.Spell[ BuffID[i] ].Rank and not (self.Spell[ BuffID[i] ].Rank == " ") then
-				SpellName_Rank = SpellName_Rank.."("..self.Spell[ BuffID[i] ].Rank..")"
-			end
+			-- local SpellName_Rank = self.Spell[ BuffID[i] ].Name
+			-- if self.Spell[ BuffID[i] ].Rank and not (self.Spell[ BuffID[i] ].Rank == " ") then
+			-- 	SpellName_Rank = SpellName_Rank.."("..self.Spell[ BuffID[i] ].Rank..")"
+			-- end
 			f:SetAttribute("type", "spell")
-			f:SetAttribute("spell", SpellName_Rank)
+			f:SetAttribute("spell", self.Spells[ BuffID[i] ].spellId)
 		end
 	end
 end
@@ -273,14 +265,14 @@ function Necrosis:CurseSpellAttribute()
 	for i = 1, #buffID, 1 do
 		local f = _G["NecrosisCurseMenu"..i]
 		if f then
-			local SpellName_Rank = self.Spell[ buffID[i] ].Name
-			if self.Spell[ buffID[i] ].Rank and not (self.Spell[ buffID[i] ].Rank == " ") then
-				SpellName_Rank = SpellName_Rank.."("..self.Spell[ buffID[i] ].Rank..")"
-			end
+			-- local SpellName_Rank = self.Spell[ buffID[i] ].Name
+			-- if self.Spell[ buffID[i] ].Rank and not (self.Spell[ buffID[i] ].Rank == " ") then
+			-- 	SpellName_Rank = SpellName_Rank.."("..self.Spell[ buffID[i] ].Rank..")"
+			-- end
 			f:SetAttribute("harmbutton", "debuff")
 			f:SetAttribute("type-debuff", "spell")
 			f:SetAttribute("unit", "target")
-			f:SetAttribute("spell-debuff", SpellName_Rank)
+			f:SetAttribute("spell-debuff", self.Spells[ buffID[i] ].spellId)
 		end
 	end
 end
@@ -299,7 +291,7 @@ function Necrosis:StoneAttribute(Steed)
 		local f = _G["Necrosis"..itemName[i].."Button"]
 		if f then
 			f:SetAttribute("type2", "spell")
-			f:SetAttribute("spell2", self.Spell[ buffID[i] ].Name..Necrosis:RankToStone(self.Spell[ buffID[i] ].Rank))
+			f:SetAttribute("spell2", self.Spells[ buffID[i] ].spellId)
 		end
 	end
 
@@ -313,10 +305,10 @@ function Necrosis:StoneAttribute(Steed)
 			NecrosisMountButton:SetAttribute("spell1", leftMountName)
 		else
 			if (self.Spell[2].ID) then
-				NecrosisMountButton:SetAttribute("spell1", self.Spell[2].Name)
-				NecrosisMountButton:SetAttribute("spell2", self.Spell[1].Name)
+				NecrosisMountButton:SetAttribute("spell1", self.Spells[2].spellId)
+				NecrosisMountButton:SetAttribute("spell2", self.Spells[1].spellId)
 			else
-				NecrosisMountButton:SetAttribute("spell*", self.Spell[1].Name)
+				NecrosisMountButton:SetAttribute("spell*", self.Spells[1].spellId)
 			end			
 		end
 		
@@ -335,6 +327,7 @@ function Necrosis:StoneAttribute(Steed)
 
 	-- if the 'Ritual of Souls' spell is known, then associate it to the hearthstone shift-click.
 	-- Cas particulier : Si le sort du Rituel des âmes existe, on l'associe au shift+clic healthstone.
+	-- not in classic (TODO remove)
 	if _G["NecrosisHealthstoneButton"] and self.Spell[50].ID then
 		NecrosisHealthstoneButton:SetAttribute("shift-type*", "spell")
 		NecrosisHealthstoneButton:SetAttribute("shift-spell*", self.Spell[50].Name)
@@ -343,7 +336,7 @@ function Necrosis:StoneAttribute(Steed)
 	-- if the 'Ritual of Summoning' spell is known, then associate it to the soulstone shift-click.
 	if _G["NecrosisSoulstoneButton"] and self.Spell[37].ID then
 		NecrosisSoulstoneButton:SetAttribute("shift-type*", "spell")
-		NecrosisSoulstoneButton:SetAttribute("shift-spell*", self.Spell[37].Name)
+		NecrosisSoulstoneButton:SetAttribute("shift-spell*", self.Spells[37].spellId)
 	end
 	
 	
@@ -514,7 +507,7 @@ function Necrosis:SoulstoneUpdateAttribute(nostone)
 	-- Un clic gauche crée la pierre
 	if nostone then
 		NecrosisSoulstoneButton:SetAttribute("type1", "spell")
-		NecrosisSoulstoneButton:SetAttribute("spell1", self.Spell[51].Name..Necrosis:RankToStone(self.Spell[51].Rank))
+		NecrosisSoulstoneButton:SetAttribute("spell1", self.Spells[51].spellId)
 		return
 	end
 
@@ -535,7 +528,7 @@ function Necrosis:HealthstoneUpdateAttribute(nostone)
 	-- Un clic gauche crée la pierre
 	if nostone then
 		NecrosisHealthstoneButton:SetAttribute("type1", "spell")
-		NecrosisHealthstoneButton:SetAttribute("spell1", self.Spell[52].Name..Necrosis:RankToStone(self.Spell[52].Rank))
+		NecrosisHealthstoneButton:SetAttribute("spell1", self.Spells[52].spellId)
 		return
 	end
 
@@ -556,7 +549,7 @@ function Necrosis:SpellstoneUpdateAttribute(nostone)
 	-- Un clic gauche crée la pierre
 	if nostone then
 		NecrosisSpellstoneButton:SetAttribute("type1", "spell")
-		NecrosisSpellstoneButton:SetAttribute("spell*", self.Spell[53].Name.."("..self.Spell[53].Rank..")")
+		NecrosisSpellstoneButton:SetAttribute("spell*", self.Spells[53].spellId)
 		return
 	end
 
@@ -574,7 +567,7 @@ function Necrosis:FirestoneUpdateAttribute(nostone)
 	-- Un clic gauche crée la pierre
 	if nostone then
 		NecrosisFirestoneButton:SetAttribute("type1", "spell")
-		NecrosisFirestoneButton:SetAttribute("spell*", self.Spell[54].Name.."("..self.Spell[54].Rank..")")
+		NecrosisFirestoneButton:SetAttribute("spell*", self.Spells[54].spellId)
 		return
 	end
 


### PR DESCRIPTION
/!\ Experimental /!\

this one may be a first step on refactoring the add-on
at least spell management and can discard localization problems on spell detection (including ranks).

the new system use (real) spell IDs so it don't relly on string manipulation,
the old system (`Necrosis:Spell`) is still in place, the new (`Necrosis:Spells`) is only in place for casting spells right now (except banish)